### PR TITLE
fix: correct frame-ancestors, trim assets, add a root index

### DIFF
--- a/build-previews.mjs
+++ b/build-previews.mjs
@@ -19,7 +19,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { cpSync, mkdirSync, readdirSync, rmSync, existsSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -62,8 +62,20 @@ function buildStatic(slug, rel) {
   const src = join(ROOT, 'projects', rel);
   const dest = join(OUT, slug);
   mkdirSync(dest, { recursive: true });
+
+  // These repos keep their README screenshots at the project root and their real assets in
+  // subfolders, so a root-level image nothing references is documentation - and expensive:
+  // meme-generator.gif alone is 5.8MB. Checked against what the code actually references rather
+  // than a hardcoded list, so an image the app does use at the root still gets copied.
+  const referenced = readdirSync(src)
+    .filter((n) => /\.(html|css|js)$/i.test(n))
+    .map((n) => readFileSync(join(src, n), 'utf8'))
+    .join('\n');
+  const isUnusedRootImage = (entry) =>
+    /\.(gif|png|jpe?g|webp|svg|ico)$/i.test(entry) && !referenced.includes(entry);
+
   for (const entry of readdirSync(src)) {
-    if (SKIP.has(entry)) continue;
+    if (SKIP.has(entry) || isUnusedRootImage(entry)) continue;
     cpSync(join(src, entry), join(dest, entry), { recursive: true });
   }
 }

--- a/build-previews.mjs
+++ b/build-previews.mjs
@@ -19,7 +19,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -89,6 +89,55 @@ function buildVite(slug, rel) {
   run('npx', ['vite', 'build', '--outDir', join(OUT, slug), '--emptyOutDir'], src);
 }
 
+// The root of this domain is otherwise a raw Vercel 404. Nothing links here - the portfolio embeds
+// /<slug>/ directly - but it is a public URL, so it should say what it is.
+function writeIndex(built) {
+  const link = (slug) => `<li><a href="/${slug}/">${slug}</a></li>`;
+  writeFileSync(
+    join(OUT, 'index.html'),
+    `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Trybe course — project previews</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin:0; padding:clamp(24px,6vw,72px); background:#0a0b0d; color:#e8eaed;
+         font:16px/1.6 ui-sans-serif,system-ui,sans-serif; }
+  main { max-width:52rem; margin:0 auto; }
+  h1 { font-size:clamp(1.4rem,4vw,2rem); margin:0 0 .5rem; }
+  p { color:#9aa0a6; margin:0 0 2rem; }
+  h2 { font-size:.75rem; text-transform:uppercase; letter-spacing:.08em; color:#5b8def;
+       margin:2rem 0 .75rem; font-family:ui-monospace,monospace; }
+  ul { list-style:none; padding:0; margin:0; display:grid; gap:.25rem;
+       grid-template-columns:repeat(auto-fill,minmax(15rem,1fr)); }
+  a { color:#e8eaed; text-decoration:none; display:block; padding:.6rem .8rem; border-radius:8px;
+      border:1px solid #23262b; font-family:ui-monospace,monospace; font-size:.9rem; }
+  a:hover, a:focus-visible { border-color:#5b8def; background:#13161a; outline:none; }
+  footer { margin-top:3rem; color:#5f6368; font-size:.85rem; }
+  footer a { display:inline; padding:0; border:0; color:#5b8def; text-decoration:underline; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Trybe course — project previews</h1>
+  <p>Static builds of coursework from 2020–21, served so my portfolio can embed them.
+     These are supporting assets, not the portfolio itself.</p>
+  <h2>// no build</h2>
+  <ul>${built.filter((s) => s in STATIC).map(link).join('')}</ul>
+  <h2>// react</h2>
+  <ul>${built.filter((s) => s in VITE).map(link).join('')}</ul>
+  <footer><a href="https://gabrielgaldinodev.vercel.app">← portfolio</a>
+    · <a href="https://github.com/GGaldino95/trybe-course">source</a></footer>
+</main>
+</body>
+</html>
+`,
+  );
+}
+
 const only = process.argv[2]; // optional: build a single slug
 const targets = [
   ...Object.entries(STATIC).map(([slug, rel]) => ({ slug, rel, build: buildStatic })),
@@ -116,6 +165,10 @@ for (const { slug, rel, build } of targets) {
     failed.push([slug, error.message.split('\n')[0]]);
   }
 }
+
+const failedSlugs = new Set(failed.map(([slug]) => slug));
+// Only list what actually built, so a skipped project is not advertised as a dead link.
+if (!only) writeIndex(targets.map((t) => t.slug).filter((s) => !failedSlugs.has(s)));
 
 console.log(`\n${targets.length - failed.length}/${targets.length} built → dist/`);
 if (failed.length) {

--- a/build-previews.mjs
+++ b/build-previews.mjs
@@ -7,7 +7,15 @@
  *   vite   - migrated off react-scripts (see the migration commit). npm install + vite build.
  *
  * The portfolio's only coupling to this repo is the resulting URL, stored per project in Sanity
- * as preview.embedUrl. Nothing here imports from the portfolio or vice versa.
+ * as preview.embedUrl - https://trybe-course.vercel.app/<slug>/. Nothing here imports from the
+ * portfolio or vice versa.
+ *
+ * Changing the portfolio's domain? vercel.json's frame-ancestors lists exactly who may iframe
+ * these previews, currently https://gabrielgaldinodev.vercel.app plus localhost:3000. A new domain
+ * has to be added there or every preview goes blank - the browser blocks the frame, and the
+ * portfolio cannot detect it, because a cross-origin iframe reports nothing about why it failed.
+ * Vercel preview deployments of the portfolio get generated hostnames and are NOT covered; add
+ * https://*-<account>.vercel.app if you need previews to work from those too.
  */
 
 import { execFileSync } from 'node:child_process';

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
         {
           "key": "Content-Security-Policy",
           "value": "frame-ancestors 'self' https://gabrielgaldinodev.vercel.app http://localhost:3000"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "frame-ancestors 'self' https://*.vercel.app"
+          "value": "frame-ancestors 'self' https://gabrielgaldinodev.vercel.app http://localhost:3000"
         }
       ]
     }


### PR DESCRIPTION
## Description

The deployed CSP is still the placeholder `frame-ancestors 'self' https://*.vercel.app`, which lets **any** site hosted on vercel.app iframe these previews — broader than having no rule at all, since it reads as deliberate.

This fix was written before #110 but did not make it into that merge, so `main` shipped with the placeholder. Verified against the live deployment:

```
$ curl -sI https://trybe-course.vercel.app/pixels-art/ | grep -i content-security
content-security-policy: frame-ancestors 'self' https://*.vercel.app
```

## Changes

### CSP

- Narrowed to `https://gabrielgaldinodev.vercel.app` (the portfolio) plus `http://localhost:3000` for local development.
- Documented the change procedure in `build-previews.mjs`, since JSON takes no comments, along with the preview `embedUrl` base now that the host is known: `https://trybe-course.vercel.app/<slug>/`.

## Notes

**This fails silently if it is ever wrong.** A blocked frame is invisible to the embedding page — a cross-origin iframe reports nothing about why it failed, so the symptom is blank previews with no error anywhere. That is why it is pinned to an exact host rather than left permissive.

**Vercel preview deployments of the portfolio are deliberately not covered.** They get generated hostnames, so iframes will not render on portfolio PR previews. Covering them means `https://*-ggaldino95.vercel.app`, which is a real widening — worth it only if testing the detail page on PR previews becomes routine.

Direct navigation is unaffected either way; `frame-ancestors` restricts framing only, so opening a preview in a new tab keeps working.